### PR TITLE
Fix for issue #14 - undefined fields returned to callback from modules.api.sql.select

### DIFF
--- a/modules/api/sql.js
+++ b/modules/api/sql.js
@@ -22,7 +22,7 @@ private.row2object = function (row) {
 			 length = this.length,
 			 i = 0; i < length; i++
 	) {
-		out[this[i]] = row[i];
+		out[this[i]] = row[this[i]];
 	}
 
 	return out;


### PR DESCRIPTION
row property values should be retrieved by using their name from the row object.
